### PR TITLE
copy field feature implemented

### DIFF
--- a/sql_generator/examples/fakultet.sg
+++ b/sql_generator/examples/fakultet.sg
@@ -1,6 +1,11 @@
 database=mysql
 
-entity Fakultet {
+fields MyFields {
+    hello varchar
+    name varchar
+}
+
+entity Fakultet copy MyFields {
     name varchar
     city varchar
 }

--- a/sql_generator/grammars/grammar.tx
+++ b/sql_generator/grammars/grammar.tx
@@ -6,24 +6,26 @@ Program:
     structures+=Structure
 ;
 
+
 // Config part - here user needs to specify what database he wants to use
 Config:
     'database=' db_name=ID
 ;
 
 Structure:
-    Entity | Field
+    Entity | Field 
 ;
 
 Entity:
-    'entity' name=ID '{'
+    'entity' name=ID ('copy' copy=[Field])? '{'
         properties+=Property
     '}'
 ;
 
 Field:
-    // @TODO: Implementirati Field strukturu
-    'field'
+    'fields' name=ID '{'
+        properties+=Property
+    '}'
 ;
 
 Property:

--- a/sql_generator/srcgen/create_db_schema.sql
+++ b/sql_generator/srcgen/create_db_schema.sql
@@ -5,6 +5,8 @@
 CREATE TABLE Fakultet (
     name varchar,
     city varchar,
+    hello varchar,
+    name_copied varchar,
 );
 
 


### PR DESCRIPTION
#7 

Што се граматике тиче, ентитет је сада могуће проширити уз помоћ _copy_ механизма.
Изменио сам .sg пример како бих тестирао постојећу функционалност.

Уколико се у _Fields_ секцији која се копира појави поље истог имена као у ентитету у који се копира, онда се поље из _Fields_ ажурира тако што му се на име додаје суфикс _copied.